### PR TITLE
chore: standardize IONOS branding in customer-facing UI fields

### DIFF
--- a/nodes/IonosCloudAiModelHub/IonosCloudAiModelHub.node.ts
+++ b/nodes/IonosCloudAiModelHub/IonosCloudAiModelHub.node.ts
@@ -13,7 +13,7 @@ export class IonosCloudAiModelHub implements INodeType {
 	usableAsTool = true;
 
 	description: INodeTypeDescription = {
-		displayName: 'Ionos Cloud (AI Model Hub)',
+		displayName: 'IONOS Cloud (AI Model Hub)',
 		name: 'ionosCloudAiModelHub',
 		icon: { light: 'file:ionos.svg', dark: 'file:ionos.dark.svg' },
 		group: ['transform'],

--- a/nodes/IonosCloudCdn/IonosCloudCdn.node.ts
+++ b/nodes/IonosCloudCdn/IonosCloudCdn.node.ts
@@ -11,15 +11,15 @@ export class IonosCloudCdn implements INodeType {
 	usableAsTool = true;
 
 	description: INodeTypeDescription = {
-		displayName: 'Ionos Cloud (CDN)',
+		displayName: 'IONOS Cloud (CDN)',
 		name: 'ionosCloudCdn',
 		icon: { light: 'file:ionos.svg', dark: 'file:ionos.dark.svg' },
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Interact with Ionos Cloud CDN API',
+		description: 'Interact with IONOS Cloud CDN API',
 		defaults: {
-			name: 'Ionos Cloud CDN',
+			name: 'IONOS Cloud CDN',
 		},
 		inputs: ['main'],
 		outputs: ['main'],

--- a/nodes/IonosCloudCertificateManager/IonosCloudCertificateManager.node.ts
+++ b/nodes/IonosCloudCertificateManager/IonosCloudCertificateManager.node.ts
@@ -9,15 +9,15 @@ import { providerDescriptions } from './resources/provider/provider';
 
 export class IonosCloudCertificateManager implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Ionos Cloud (Certificate Manager)',
+		displayName: 'IONOS Cloud (Certificate Manager)',
 		name: 'ionosCloudCertificateManager',
 		icon: { light: 'file:ionos.svg', dark: 'file:ionos.dark.svg' },
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Interact with Ionos Cloud Certificate Manager API v2',
+		description: 'Interact with IONOS Cloud Certificate Manager API v2',
 		defaults: {
-			name: 'Ionos Cloud (Certificate Manager)',
+			name: 'IONOS Cloud (Certificate Manager)',
 		},
 		usableAsTool: true,
 		inputs: [NodeConnectionTypes.Main],

--- a/nodes/IonosCloudCloudApi/IonosCloudCloudApi.node.ts
+++ b/nodes/IonosCloudCloudApi/IonosCloudCloudApi.node.ts
@@ -23,7 +23,7 @@ import { targetGroupDescription } from './resources/targetGroup';
 
 export class IonosCloudCloudApi implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Ionos Cloud (Infrastructure)',
+		displayName: 'IONOS Cloud (Infrastructure)',
 		name: 'ionosCloudCloudApi',
 		icon: { light: 'file:ionos.svg', dark: 'file:ionos.dark.svg' },
 		group: ['transform'],
@@ -31,7 +31,7 @@ export class IonosCloudCloudApi implements INodeType {
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Manage IONOS Cloud infrastructure resources',
 		defaults: {
-			name: 'Ionos Cloud (Infrastructure)',
+			name: 'IONOS Cloud (Infrastructure)',
 		},
 		usableAsTool: true,
 		inputs: [NodeConnectionTypes.Main],

--- a/nodes/IonosCloudDns/IonosCloudDns.node.ts
+++ b/nodes/IonosCloudDns/IonosCloudDns.node.ts
@@ -17,15 +17,15 @@ import { reverseRecordDescriptions } from './resources/reverseRecord/reverseReco
 
 export class IonosCloudDns implements INodeType {
 	description: INodeTypeDescription = {
-		displayName: 'Ionos Cloud (Cloud DNS)',
+		displayName: 'IONOS Cloud (Cloud DNS)',
 		name: 'ionosCloudDns',
 		icon: { light: 'file:ionos.svg', dark: 'file:ionos.dark.svg' },
 		group: ['transform'],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Interact with Ionos Cloud DNS API v1',
+		description: 'Interact with IONOS Cloud DNS API v1',
 		defaults: {
-			name: 'Ionos Cloud (Cloud DNS)',
+			name: 'IONOS Cloud (Cloud DNS)',
 		},
 		usableAsTool: true,
 		inputs: [NodeConnectionTypes.Main],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ionos-cloud/n8n-nodes-ionos-cloud",
   "version": "1.0.0",
-  "description": "n8n community nodes for IONOS Cloud services (Infrastructure, Certificate Manager, DNS, CDN, AI Model Hub)",
+  "description": "Official n8n community nodes for IONOS Cloud services (Infrastructure, Certificate Manager, DNS, CDN, AI Model Hub)",
   "license": "MIT",
   "homepage": "https://www.ionos.com/cloud",
   "keywords": [


### PR DESCRIPTION
- Update displayName to 'IONOS Cloud' (uppercase) across all nodes
- Update descriptions to use 'IONOS Cloud' consistently
- Update default node names for better brand consistency
- Add 'Official' to package description

Affected nodes:
- CDN
- DNS (Cloud DNS)
- Infrastructure (Cloud API)
- AI Model Hub
- Certificate Manager