### PR TITLE
fix: unblock CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Update npm for trusted publishing (OIDC)
+        run: npm install -g npm@latest
+
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=critical
 
@@ -37,4 +40,4 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_MODE: true


### PR DESCRIPTION
## Summary
- Set `RELEASE_MODE=true` for the npm publish step so `n8n-node`'s CI publish isn't blocked by its interactive-release gate.
- Remove the unused NPM_TOKEN environment variable; publishing uses npm trusted publishers (OIDC) instead.
- Upgrade npm before publishing to ensure OIDC trusted publishing support.