### PR TITLE
fix: publish via npm run release so the release workflow passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,7 @@ jobs:
       - name: Audit dependencies
         run: npm audit --omit=dev --audit-level=critical
 
-      - name: Build
-        run: npm run build
-
       - name: Publish to npm
-        run: npm publish --provenance
+        run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The Release workflow fails at the publish step with exit code 1.

`npm publish --provenance` runs the package's `prepublishOnly` hook, which calls `n8n-node prerelease`. That command is a deliberate guard: it exits 1 unless `RELEASE_MODE` is set, printing "Run \`npm run release\` to publish the package". Publishing directly never sets it, so the job always fails.

`n8n-node release` is the intended entry point. When it detects `GITHUB_ACTIONS` it runs lint and build, then `npm publish` with `RELEASE_MODE=true` and `NPM_CONFIG_PROVENANCE=true` set — satisfying the guard and keeping provenance on.

This swaps the direct build + publish steps for `npm run release` (the standalone Build step is now redundant since the release command builds itself).