### PR TITLE
docs: mention the de/fra/1 location in the datacenter location field

### DIFF
--- a/nodes/IonosCloudCloudApi/resources/datacenter/datacenter.ts
+++ b/nodes/IonosCloudCloudApi/resources/datacenter/datacenter.ts
@@ -106,7 +106,7 @@ export const datacenterDescriptions: INodeProperties[] = [
 		displayOptions: { show: showForDatacenterCreate },
 		default: 'us/las',
 		description:
-			'The physical location where the datacenter will be created (e.g., us/las, de/fra, de/txl). Property cannot be modified after creation.',
+			'The physical location where the datacenter will be created (e.g., us/las, de/fra, de/fra/1, de/txl). Property cannot be modified after creation.',
 		routing: {
 			send: {
 				type: 'body',


### PR DESCRIPTION
Adds `de/fra/1` (Frankfurt West) to the example locations in the datacenter Location field description. Nothing is validated client-side, so this is purely so the new location is discoverable in the UI.